### PR TITLE
Custom name section support

### DIFF
--- a/src/Wacil.Compiler/Emit/CustomAttribute.fs
+++ b/src/Wacil.Compiler/Emit/CustomAttribute.fs
@@ -16,3 +16,8 @@ let markCompilerGenerated (syslib: SystemLibrary.References): Marker =
 let markImportConstructor (rtlib: RuntimeLibrary.References): Marker =
     fun parent ->
         parent.CustomAttributes.Add(CustomAttribute(rtlib.ImportConstructorAttribute, emptyAttributeSignature))
+
+let markCustomName (corLibTypes: Types.CorLibTypeFactory) (rtlib: RuntimeLibrary.References): string -> Marker =
+    fun name parent ->
+        let signature = CustomAttributeSignature([| CustomAttributeArgument(corLibTypes.String, name) |])
+        parent.CustomAttributes.Add(CustomAttribute(rtlib.CustomNameAttribute, signature))

--- a/src/Wacil.Compiler/Emit/FunctionTranslator.fs
+++ b/src/Wacil.Compiler/Emit/FunctionTranslator.fs
@@ -15,6 +15,7 @@ open AsmResolver.DotNet.Code.Cil
 
 let translateFunctionDefinitions
     mangleMemberName
+    (markCompilerGenerated: CustomAttribute.Marker)
     (translateFuncType: _ -> MethodSignature)
     (rtlib: RuntimeLibrary.References)
     (moduleClassDefinition: TypeDefinition)
@@ -65,6 +66,7 @@ let translateFunctionDefinitions
                     MethodAttributes.Static
                     ("__call_function@" + functionIndexString)
 
+            markCompilerGenerated definition
             definition.CilMethodBody <- CilMethodBody definition
             definition.ImplAttributes <- CilHelpers.methodImplAggressiveInlining
             let il = definition.CilMethodBody.Instructions

--- a/src/Wacil.Compiler/Emit/Module.fs
+++ b/src/Wacil.Compiler/Emit/Module.fs
@@ -125,6 +125,8 @@ let compileToModuleDefinition (options: Options) (input: ValidModule) =
             options.MemoryImportImplementation
             members
 
+    let markCustomName = CustomAttribute.markCustomName mdle.CorLibTypeFactory rtlib
+
     MemoryTranslator.translateModuleMemories
         mangleMemberName
         rtlib
@@ -156,8 +158,9 @@ let compileToModuleDefinition (options: Options) (input: ValidModule) =
     FunctionTranslator.translateFunctionDefinitions
         mangleMemberName
         markCompilerGenerated
+        markCustomName
         translateFuncType
-        rtlib
+        options.CustomNames
         mainClassDefinition
         mainClassSignature
         input

--- a/src/Wacil.Compiler/Emit/Module.fs
+++ b/src/Wacil.Compiler/Emit/Module.fs
@@ -155,6 +155,7 @@ let compileToModuleDefinition (options: Options) (input: ValidModule) =
 
     FunctionTranslator.translateFunctionDefinitions
         mangleMemberName
+        markCompilerGenerated
         translateFuncType
         rtlib
         mainClassDefinition

--- a/src/Wacil.Compiler/Emit/Options.fs
+++ b/src/Wacil.Compiler/Emit/Options.fs
@@ -41,10 +41,26 @@ type Options (name) =
 
     member val OutputType = OutputType.Assembly(System.Version(1, 0, 0, 0)) with get, set
 
-    member val OutputName = if System.String.IsNullOrEmpty name then "Module" else name
-
     /// <summary>Indicates the version of the <c>Wacil.Runtime</c> library being referenced.</summary>
     member val RuntimeVersion = System.Version(1, 0, 0, 0) with get, set
+
+    /// <summary>Indicates the WebAssembly custom name section to use.</summary>
+    member val CustomNames = Option<Wacil.Compiler.Wasm.CustomNames.Lookup>.None with get, set
+
+    member this.OutputName =
+        let mutable selection = name
+        let inline selectOutputName other =
+            selection <-
+                if System.String.IsNullOrEmpty name
+                then other
+                else name
+
+        match this.CustomNames with
+        | Some(names) -> selectOutputName names.ModuleName
+        | None -> ()
+
+        selectOutputName "module"
+        selection
 
     /// <summary>
     /// The name of the generated class corresponding to the WASM module. Defaults to the

--- a/src/Wacil.Compiler/Emit/RuntimeLibrary.fs
+++ b/src/Wacil.Compiler/Emit/RuntimeLibrary.fs
@@ -98,7 +98,8 @@ type References =
       /// <summary>Instantiates the <c>Wacil.Runtime.Global&lt;T&gt;</c> class.</summary>
       InstantiatedGlobal: Wasm.Format.ValType -> GlobalInstantiation
       InstantiatedMemory: MemoryImplementation -> MemoryInstantiation
-      ImportConstructorAttribute: ICustomAttributeType }
+      ImportConstructorAttribute: ICustomAttributeType
+      CustomNameAttribute: ICustomAttributeType }
 
 let importTypes runtimeLibraryVersion wasmTypeTranslator (syslib: SystemLibrary.References) (mdle: ModuleDefinition) =
     let name = "Wacil.Runtime"
@@ -428,4 +429,8 @@ let importTypes runtimeLibraryVersion wasmTypeTranslator (syslib: SystemLibrary.
       ImportConstructorAttribute =
         importRuntimeType "ImportConstructorAttribute"
         |> ImportHelpers.importConstructor mdle Seq.empty
+        :?> ICustomAttributeType
+      CustomNameAttribute =
+        importRuntimeType "CustomNameAttribute"
+        |> ImportHelpers.importConstructor mdle [| mdle.CorLibTypeFactory.String |]
         :?> ICustomAttributeType }

--- a/src/Wacil.Compiler/Helpers/IO/ReadOnlyMemoryStream.fs
+++ b/src/Wacil.Compiler/Helpers/IO/ReadOnlyMemoryStream.fs
@@ -1,0 +1,38 @@
+namespace Wacil.Compiler.Helpers.IO
+
+open System
+
+[<Sealed>]
+type internal ReadOnlyMemoryStream (bytes: ReadOnlyMemory<byte>) =
+    inherit IO.Stream()
+
+    let mutable current = bytes
+
+    new (bytes: Collections.Immutable.ImmutableArray<byte>) =
+        new ReadOnlyMemoryStream(bytes.AsMemory())
+
+    override _.CanRead = true
+    override _.CanSeek = false
+    override _.CanWrite = false
+
+    override _.Read(buffer: Span<byte>) =
+        let length = min buffer.Length current.Length
+        current.Span.Slice(0, length).CopyTo(buffer)
+        current <- current.Slice length
+        length
+
+    override this.Read(buffer: byte[], offset, count) = this.Read(Span(buffer, offset, count))
+
+    override _.Seek(offset: int64, origin: IO.SeekOrigin) = raise(NotSupportedException())
+
+    override _.Length = raise(NotSupportedException())
+
+    override _.Position
+        with get() = raise(NotSupportedException())
+        and set _ = raise(NotSupportedException())
+
+    override _.SetLength(length: int64) = raise(NotSupportedException())
+
+    override _.Write(buffer: byte[], offset: int, count: int) = raise(NotSupportedException())
+
+    override _.Flush() = ()

--- a/src/Wacil.Compiler/Wacil.Compiler.fsproj
+++ b/src/Wacil.Compiler/Wacil.Compiler.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="Helpers\Unsafe.fsi" />
     <Compile Include="Helpers\Unsafe.fs" />
     <Compile Include="Helpers\Collections\ArrayBuilder.fs" />
+    <Compile Include="Helpers\IO\ReadOnlyMemoryStream.fs" />
 
     <Compile Include="Wasm\Format.fsi" />
     <Compile Include="Wasm\Format.fs" />
@@ -21,6 +22,8 @@
     <Compile Include="Wasm\Validation\Table.fs" />
     <Compile Include="Wasm\Validation\ValidModule.fsi" />
     <Compile Include="Wasm\Validation\ValidModule.fs" />
+    <Compile Include="Wasm\CustomNames.fsi" />
+    <Compile Include="Wasm\CustomNames.fs" />
     <Compile Include="Wasm\Disassemble.fsi" />
     <Compile Include="Wasm\Disassemble.fs" />
 

--- a/src/Wacil.Compiler/Wasm/CustomNames.fs
+++ b/src/Wacil.Compiler/Wasm/CustomNames.fs
@@ -91,7 +91,7 @@ let parseFromData (data: ImmutableArray<byte>) =
                         let index: Format.LocalIdx = reader.ReadIndex()
                         if not(locals.TryAdd(index, reader.ReadName())) then
                             failwithf "Local #%i in function #%i already has name" (int32 index) (int32 parent)
-            | bad -> failwithf "0x%02X is not a valid name subsection ID" bad
+            | _ -> reader.Skip size // Unknown sections are skipped
 
             let actualSubsectionSize = reader.Offset - subsectionStartOffset
             if actualSubsectionSize <> size then

--- a/src/Wacil.Compiler/Wasm/CustomNames.fs
+++ b/src/Wacil.Compiler/Wasm/CustomNames.fs
@@ -1,0 +1,104 @@
+module Wacil.Compiler.Wasm.CustomNames
+
+open System.Collections.Generic
+open System.Collections.Immutable
+
+open Wacil.Compiler.Helpers
+
+type ParseException = Parser.ParseException
+
+[<NoComparison; NoEquality>]
+type FunctionNames =
+    { mutable Name: string
+      mutable Locals: Dictionary<Format.LocalIdx, string> }
+
+[<Sealed>]
+type Lookup
+    (
+        mdle: string,
+        functions: Dictionary<Format.FuncIdx, FunctionNames>
+    )
+    =
+    member _.ModuleName = mdle
+
+    member _.GetFunctionName index =
+        match functions.TryGetValue index with
+        | true, entry -> entry.Name
+        | false, _ -> System.String.Empty
+
+    member _.GetLocalName(parent, index) =
+        match functions.TryGetValue parent with
+        | true, { Locals = null } | false, _ -> System.String.Empty
+        | true, entry ->
+            match entry.Locals.TryGetValue index with
+            | true, name -> name
+            | false, _ -> System.String.Empty
+
+let parseFromData (data: ImmutableArray<byte>) =
+    let reader = Parser.Reader(new IO.ReadOnlyMemoryStream(data))
+    try
+        let mutable mdle = System.String.Empty
+        let functions = Dictionary()
+
+        let subsectionTagBuffer = Span.stackalloc 1
+        let highestSubsectionTag = ValueSome 0uy
+        while reader.Read subsectionTagBuffer > 0 do
+            let size = reader.ReadUnsignedInteger() |> Checked.int32
+            let subsectionStartOffset = reader.Offset
+
+            let id = subsectionTagBuffer[0]
+            if highestSubsectionTag.IsSome && id < highestSubsectionTag.Value then
+                failwithf "Name subsection IDs must be in descending order and may only appear once"
+
+            match id with
+            | 0uy -> mdle <- reader.ReadName()
+            | 1uy ->
+                for _ = 1 to Checked.int32(reader.ReadUnsignedInteger()) do
+                    let index: Format.FuncIdx = reader.ReadIndex()
+                    let entry =
+                        match functions.TryGetValue index with
+                        | true, ({ Name = "" } as existing) -> existing
+                        | true, _ -> failwithf "Name already exists for function #%i" (int32 index)
+                        | false, _ ->
+                            let entry = { Name = System.String.Empty; Locals = null }
+                            functions[index] <- entry
+                            entry
+
+                    entry.Name <- reader.ReadName()
+            | 2uy ->
+                for _ = 1 to Checked.int32(reader.ReadUnsignedInteger()) do
+                    let parent: Format.FuncIdx = reader.ReadIndex()
+                    let localNameCount = Checked.int32(reader.ReadUnsignedInteger())
+                    let locals =
+                        match functions.TryGetValue parent with
+                        | true, ({ Locals = null } as entry) ->
+                            entry.Locals <- Dictionary localNameCount
+                            entry.Locals
+                        | true, _ -> failwithf "Local names already exist for function #%i" (int32 parent)
+                        | false, _ ->
+                            let entry = { Name = System.String.Empty; Locals = Dictionary localNameCount }
+                            functions[parent] <- entry
+                            entry.Locals
+
+                    for _ = 1 to localNameCount do
+                        let index: Format.LocalIdx = reader.ReadIndex()
+                        if not(locals.TryAdd(index, reader.ReadName())) then
+                            failwithf "Local #%i in function #%i already has name" (int32 index) (int32 parent)
+            | bad -> failwithf "0x%02X is not a valid name subsection ID" bad
+
+            let actualSubsectionSize = reader.Offset - subsectionStartOffset
+            if actualSubsectionSize <> size then
+                failwithf "expected %A name subsection to contain 0x%02X bytes, but got 0x%02X bytes" id size actualSubsectionSize
+
+        Ok(Lookup(mdle, functions))
+    with
+    | ex -> Error(ParseException(reader.Offset, ex))
+
+let getCustomNames (mdle: Validation.ValidModule) =
+    let mutable result = None
+    let mutable index = 0
+    while result.IsNone && index < mdle.CustomSections.Length do
+        let section = mdle.CustomSections[index]
+        if section.Name = "name" then result <- Some(parseFromData section.Contents)
+        index <- index + 1
+    result

--- a/src/Wacil.Compiler/Wasm/CustomNames.fsi
+++ b/src/Wacil.Compiler/Wasm/CustomNames.fsi
@@ -1,0 +1,30 @@
+/// <summary>Contains functions for parsing the contents of a WebAssembly custom name section.</summary>
+/// <remarks>
+/// Note that since the WebAssembly specification essentially says that errors in custom sections should be ignored, errors encountered
+/// during parsing do not throw an exception.
+/// </remarks>
+[<RequireQualifiedAccess>]
+module Wacil.Compiler.Wasm.CustomNames
+
+type ParseException = Parser.ParseException
+
+[<Sealed; Class>]
+type Lookup =
+    /// <summary>Gets the name, if any, that is assigned to the WebAssembly module.</summary>
+    member ModuleName : Format.Name
+
+    /// <summary>Gets the name corresponding to the function specified by the <paramref name="index"/>.</summary>
+    member GetFunctionName : index: Format.FuncIdx -> Format.Name
+
+    /// <summary>Gets the name of a local variable within the specified <paramref name="parent"/> function.</summary>
+    member GetLocalName : parent: Format.FuncIdx * index: Format.LocalIdx -> Format.Name
+
+/// <summary>Parses a custom name section.</summary>
+val parseFromData : data: System.Collections.Immutable.ImmutableArray<byte> -> Result<Lookup, ParseException>
+
+/// <summary>Attempts to retrieve a custom name section from a module's custom sections.</summary>
+/// <returns>
+/// <c>Some(Ok)</c> if the custom names were retrieved, <c>Some(Error)</c> if the custom name section is malformed, or <c>None</c> if the
+/// module does not contain a custom name section.
+/// </returns>
+val getCustomNames : Validation.ValidModule -> Result<Lookup, ParseException> option

--- a/src/Wacil.Compiler/Wasm/Parser.fs
+++ b/src/Wacil.Compiler/Wasm/Parser.fs
@@ -539,13 +539,13 @@ let parseFromStream (stream: Stream) =
 
                 match LanguagePrimitives.EnumOfValue(sectionTagBuffer[0]) with
                 | SectionId.Custom ->
-                    { Custom.Name = reader.ReadName()
-                      Custom.Contents =
-                        let contents = Array.zeroCreate(size - (reader.Offset - sectionStartOffset))
-                        reader.ReadAll(Span(contents))
-                        Unsafe.Array.toImmutable contents }
-                    |> Section.Custom
-                    |> sections.Add
+                    let custom =
+                        { Custom.Name = reader.ReadName()
+                          Custom.Contents =
+                            let contents = Array.zeroCreate(size - (reader.Offset - sectionStartOffset))
+                            reader.ReadAll(Span(contents))
+                            Unsafe.Array.toImmutable contents }
+                    sections.Add(Section.Custom custom)
                 | SectionId.Type ->
                     let types = Array.zeroCreate(reader.ReadUnsignedInteger() |> Checked.int32)
                     for i = 0 to types.Length - 1 do types[i] <- reader.ReadFuncType()

--- a/src/Wacil.Compiler/Wasm/Parser.fs
+++ b/src/Wacil.Compiler/Wasm/Parser.fs
@@ -47,6 +47,13 @@ type Reader (source: Stream, byteArrayPool: ArrayPool<byte>) =
             |> raise
         offset <- offset + read
 
+    member this.Skip(length: int) =
+        let buffer = Span.stackalloc(if length <= 1024 then length else 1024)
+        let mutable remaining = length
+        while remaining > 0 do
+            this.ReadAll buffer
+            remaining <- remaining - buffer.Length
+
     member this.ReadByte() =
         let mutable value = 0uy
         this.ReadAll(Span.ofByRef(&value))

--- a/src/Wacil.Compiler/Wasm/Parser.fs
+++ b/src/Wacil.Compiler/Wasm/Parser.fs
@@ -5,7 +5,6 @@ open System.Buffers
 open System.Buffers.Binary
 open System.Collections.Immutable
 open System.IO
-open System.Runtime.CompilerServices
 open System.Text
 
 open Wacil.Compiler.Helpers
@@ -30,6 +29,8 @@ type Reader (source: Stream, byteArrayPool: ArrayPool<byte>) =
     let [<Literal>] SignMask = 0b0100_0000uy
 
     let mutable offset = 0
+
+    new (source: Stream) = Reader(source, ArrayPool.Shared)
 
     member _.Offset = offset
 
@@ -508,7 +509,7 @@ let parseFromStream (stream: Stream) =
     try
         if not stream.CanRead then invalidArg (nameof stream) "The stream must support reading"
 
-        let reader = Reader(stream, ArrayPool.Shared)
+        let reader = new Reader(stream)
         try
             let magicNumberBuffer = Span.stackalloc 4
 

--- a/src/Wacil.Compiler/Wasm/Parser.fsi
+++ b/src/Wacil.Compiler/Wasm/Parser.fsi
@@ -20,6 +20,7 @@ type internal Reader =
     member ReadFloat64 : unit -> double
     member ReadName : unit -> Format.Name
     member Offset : int
+    member Skip : length: int -> unit
 
 [<Sealed; Class>]
 type InvalidMagicException =

--- a/src/Wacil.Compiler/Wasm/Parser.fsi
+++ b/src/Wacil.Compiler/Wasm/Parser.fsi
@@ -6,6 +6,22 @@ module Wacil.Compiler.Wasm.Parser
 open System.Collections.Immutable
 
 [<Sealed; Class>]
+type internal Reader =
+    new : source: System.IO.Stream -> Reader
+
+    member ReadByte : unit -> byte
+    member Read : buffer: System.Span<byte> -> int
+    member ReadAll : buffer: System.Span<byte> -> unit
+    member ReadUnsignedInteger : unit -> uint64
+    member inline ReadIndex : unit -> ^T when ^T : (static member From: uint64 -> 'T)
+    member ReadSignedInteger : unit -> int64
+    member ReadSignedIntegerOrNegativeZero : unit -> int64 voption
+    member ReadFloat32 : unit -> single
+    member ReadFloat64 : unit -> double
+    member ReadName : unit -> Format.Name
+    member Offset : int
+
+[<Sealed; Class>]
 type InvalidMagicException =
     inherit System.Exception
 
@@ -14,6 +30,8 @@ type InvalidMagicException =
 [<Sealed; Class>]
 type ParseException =
     inherit System.Exception
+
+    new : offset: int * inner: exn -> ParseException
 
     member Offset : int
 

--- a/src/Wacil.Runtime/CustomNameAttribute.cs
+++ b/src/Wacil.Runtime/CustomNameAttribute.cs
@@ -1,0 +1,15 @@
+namespace Wacil.Runtime;
+
+using System;
+
+/// <summary>Indicates that the specified member had an entry in the custom name section when it was translated from WebAssembly.</summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Delegate | AttributeTargets.Method | AttributeTargets.Property)]
+public sealed class CustomNameAttribute : Attribute {
+    /// <summary>The custom name.</summary>
+    public string Name;
+
+    /// <summary>Constructs a new instance of the <see cref="CustomNameAttribute"/> class.</summary>
+    public CustomNameAttribute(string name) {
+        Name = name;
+    }
+}

--- a/src/Wacil/Program.fs
+++ b/src/Wacil/Program.fs
@@ -72,11 +72,12 @@ let main argv =
                 | Some file' -> file'
                 | None -> FileNotFoundException("No WebAssembly files were found in the current directory") |> raise
 
-        let input' =
-            use reader = input.OpenRead()
-            Compiler.Wasm.Parser.parseFromStream reader
+        let input'' =
+            let input' =
+                use reader = input.OpenRead()
+                Compiler.Wasm.Parser.parseFromStream reader
 
-        let input'' = Compiler.Wasm.Validation.Validate.fromModuleSections input'
+            Compiler.Wasm.Validation.Validate.fromModuleSections input'
         
         if args.Contains <@ Debug_Disassemble @> then
             Compiler.Wasm.Disassemble.disassembleToWriter input'' Console.Out

--- a/src/Wacil/Program.fs
+++ b/src/Wacil/Program.fs
@@ -102,7 +102,7 @@ let main argv =
             if args.Contains <@ Omit_Custom_Names @>
             then None
             else
-                match Compiler.Wasm.CustomNames.getCustomNames input''.CustomSections with
+                match Compiler.Wasm.CustomNames.getCustomNames input'' with
                 | Some(Ok names) -> Some names
                 | Some(Error e) ->
                     eprintfn "Invalid custom name section: %A" e


### PR DESCRIPTION
Adds support for parsing of the custom `name` section and for usage of some custom names in function translation